### PR TITLE
Brings basic Dolittle Runtime Event Store support

### DIFF
--- a/Environments/mongo-and-runtime.sh
+++ b/Environments/mongo-and-runtime.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f ./mongo-and-runtime.yml up

--- a/Environments/mongo-and-runtime.yml
+++ b/Environments/mongo-and-runtime.yml
@@ -1,0 +1,24 @@
+version: '3.1'
+services:
+  mongo:
+    image: dolittle/mongodb
+    hostname: mongo
+    volumes:
+      - ${PWD}/data:/data
+    ports:
+      - 27018:27017
+ 
+  runtime:
+    image: dolittle/runtime:5.0.0-rc.3
+    depends_on: 
+      - mongo
+    links:
+      - mongo
+    volumes:
+      - ${PWD}/resources.json:/app/.dolittle/resources.json
+      - ${PWD}/tenants.json:/app/.dolittle/tenants.json
+    ports:
+      - 82:81
+      - 9701:9700
+      - 51052:50052
+      - 51053:50053

--- a/Environments/mongo-and-runtime.yml
+++ b/Environments/mongo-and-runtime.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ${PWD}/data:/data
     ports:
-      - 27018:27017
+      - 27017:27017
  
   runtime:
     image: dolittle/runtime:5.0.0-rc.3
@@ -18,7 +18,7 @@ services:
       - ${PWD}/resources.json:/app/.dolittle/resources.json
       - ${PWD}/tenants.json:/app/.dolittle/tenants.json
     ports:
-      - 82:81
-      - 9701:9700
-      - 51052:50052
-      - 51053:50053
+      - 81:81
+      - 9700:9700
+      - 50052:50052
+      - 50053:50053

--- a/Environments/resources.json
+++ b/Environments/resources.json
@@ -1,0 +1,10 @@
+{
+    "c59abefd-f72a-4684-ad7f-dfdd2c466fec": {
+        "eventStore": {
+            "servers": [
+                "mongo"
+            ],
+            "database": "event_store"
+        }
+    }
+}

--- a/Environments/tenants.json
+++ b/Environments/tenants.json
@@ -1,0 +1,3 @@
+{
+    "c59abefd-f72a-4684-ad7f-dfdd2c466fec": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Libertas
 
+[Libertas](https://en.wikipedia.org/wiki/Libertas) is the Roman goddess and personification of liberty.
+This project is dedicated to getting data from data centric systems in an easy way into an Event Driven
+Microservice oriented world.
+
 ## Getting started
 
 Prerequisites:
 
 * [NodeJS](https://nodejs.org)
 * [Yarn](https://yarnpkg.com)
+* [Docker](https://docker.com)
 
 This repository leverages Yarn workspaces.
 
@@ -14,6 +19,22 @@ At the root of the repository, do the following from your terminal:
 ```shell
 $ yarn
 ```
+
+## Dolittle Runtime
+
+Some of the Node-RED Nodes in this project is built to support the Dolittle Runtime.
+In order to develop on these leveraging the [Testbench](./Testbench) for instance, you'll
+have to have the runtime running with an appropriate storage for the events.
+
+Within the [Environments](./Environments) folder you'll find a pre-configured environment
+that can be used for this purpose in the form of a [Docker compose](https://docs.docker.com/compose/)
+environment. By running the following in your terminal, you should have it all running:
+
+```shell
+$ ./mongo-and-runtime.sh
+```
+
+It configures a tenant with the necessary resources for it. The tenant id is: **c59abefd-f72a-4684-ad7f-dfdd2c466fec**.
 
 ## Building any of the Node-RED projects
 

--- a/Source/node-red-infor-m3/tsconfig.json
+++ b/Source/node-red-infor-m3/tsconfig.json
@@ -4,5 +4,6 @@
         "rootDir": "nodes",
         "baseUrl": "./",
         "sourceRoot": "./nodes",
+        "outDir": "./Distribution"
     }
 }

--- a/Source/node-red/nodes/change-tracker/change-tracker.html
+++ b/Source/node-red/nodes/change-tracker/change-tracker.html
@@ -1,3 +1,5 @@
+<!-- Copyright (c) Dolittle.  All Rights Reserved.  Licensed under the MIT License. See LICENSE file in the project root for full license information. -->
+
 <script type="text/javascript">
     RED.nodes.registerType('change-tracker', {
         category: 'function',

--- a/Source/node-red/nodes/change-tracker/change-tracker.ts
+++ b/Source/node-red/nodes/change-tracker/change-tracker.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 import { NodeProperties, Red } from 'node-red';
 
 import { Node } from '../../Node';

--- a/Source/node-red/nodes/dolittle-datastore-config/dolittle-datastore-config.html
+++ b/Source/node-red/nodes/dolittle-datastore-config/dolittle-datastore-config.html
@@ -1,3 +1,5 @@
+<!-- Copyright (c) Dolittle.  All Rights Reserved.  Licensed under the MIT License. See LICENSE file in the project root for full license information. -->
+
 <script type="text/javascript">
     RED.nodes.registerType('dolittle-datastore-config', {
         category: 'config',

--- a/Source/node-red/nodes/dolittle-datastore-config/dolittle-datastore-config.ts
+++ b/Source/node-red/nodes/dolittle-datastore-config/dolittle-datastore-config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 import { NodeProperties, Red } from 'node-red';
 
 import { Node } from '../../Node';

--- a/Source/node-red/nodes/dolittle-runtime-config/dolittle-runtime-config.html
+++ b/Source/node-red/nodes/dolittle-runtime-config/dolittle-runtime-config.html
@@ -1,9 +1,13 @@
+<!-- Copyright (c) Dolittle.  All Rights Reserved.  Licensed under the MIT License. See LICENSE file in the project root for full license information. -->
+
 <script type="text/javascript">
     RED.nodes.registerType('dolittle-runtime-config', {
         category: 'config',
         color: '#FF4B00',
         icon: 'dolittle.png',
         defaults: {
+            tenant: { value: '', required: true },
+            microservice: { value: '', required: true },
             name: { value: '', required: true },
             host: { value: "localhost", required: true },
             port: { value: 50053, required: true, validate: RED.validators.number() }
@@ -15,6 +19,14 @@
 </script>
 
 <script type="text/html" data-template-name="dolittle-runtime-config">
+    <div class="form-row">
+        <label for="node-config-input-tenant"><i class="icon-bookmark"></i> Tenant</label>
+        <input type="text" id="node-config-input-tenant">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-microservice"><i class="icon-bookmark"></i> Microservice</label>
+        <input type="text" id="node-config-input-microservice">
+    </div>
     <div class="form-row">
         <label for="node-config-input-name"><i class="icon-bookmark"></i> Name</label>
         <input type="text" id="node-config-input-name">

--- a/Source/node-red/nodes/dolittle-runtime-config/dolittle-runtime-config.ts
+++ b/Source/node-red/nodes/dolittle-runtime-config/dolittle-runtime-config.ts
@@ -33,10 +33,6 @@ module.exports = function (RED: Red) {
             this.port = c.port;
 
             this.createNode(config);
-
-            this.on('input', (msg) => {
-                this.send(msg);
-            });
         }
     }
 

--- a/Source/node-red/nodes/dolittle-runtime-config/dolittle-runtime-config.ts
+++ b/Source/node-red/nodes/dolittle-runtime-config/dolittle-runtime-config.ts
@@ -1,8 +1,13 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 import { NodeProperties, Red } from 'node-red';
 
 import { Node } from '../../Node';
 
 export interface DolittleRuntimeConfig {
+    tenant: string;
+    microservice: string;
     name: string;
     host: string;
     port: number;
@@ -11,6 +16,8 @@ export interface DolittleRuntimeConfig {
 module.exports = function (RED: Red) {
 
     class DolittleRuntimeConfig extends Node implements DolittleRuntimeConfig {
+        tenant: string = '';
+        microservice: string = '';
         name: string = '';
         host: string = '';
         port: number = 0;
@@ -19,6 +26,8 @@ module.exports = function (RED: Red) {
             super(RED);
 
             const c = config as any;
+            this.tenant = c.tenant;
+            this.microservice = c.microservice;
             this.name = c.name;
             this.host = c.host;
             this.port = c.port;

--- a/Source/node-red/nodes/event-store/event-store.html
+++ b/Source/node-red/nodes/event-store/event-store.html
@@ -24,5 +24,28 @@
 </script>
 
 <script type="text/html" data-help-name="event-store">
-    <p></p>
+    <p>Enables committing private and public events to the Dolittle Event Store API</p>
+
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">JSON</span>
+    </dl>
+
+    <h3>Details</h3>
+    <p>
+        <code>msg.payload</code> is used to hold the metadata and content of the event to publish
+        in the form of a well defined JSON structure.
+        <br>
+        <code>
+            {<br>
+            &nbsp;"artifact": "(GUID representing the artifact)",<br>
+            &nbsp;"eventSourceId": "{GUID representing the event source}",<br>
+            &nbsp;"public": true | false,<br>
+            &nbsp;"content": {<br>
+            &nbsp;&nbsp;"key": "value"<br>
+            &nbsp;}<br>
+            }<br>    
+        </code>
+    </p>
+
 </script>

--- a/Source/node-red/nodes/event-store/event-store.html
+++ b/Source/node-red/nodes/event-store/event-store.html
@@ -1,3 +1,5 @@
+<!-- Copyright (c) Dolittle.  All Rights Reserved.  Licensed under the MIT License. See LICENSE file in the project root for full license information. -->
+
 <script type="text/javascript">
     RED.nodes.registerType('event-store', {
         category: 'function',

--- a/Source/node-red/nodes/event-store/event-store.ts
+++ b/Source/node-red/nodes/event-store/event-store.ts
@@ -1,21 +1,46 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 import { NodeProperties, Red } from 'node-red';
 
 import { Node } from '../../Node';
 
+import { Client } from '@dolittle/sdk';
+import { DolittleRuntimeConfig } from '../dolittle-runtime-config/dolittle-runtime-config';
+import { Guid } from '@dolittle/rudiments';
+
 module.exports = function (RED: Red) {
 
     class EventStore extends Node {
-        server?: any;
+        server?: DolittleRuntimeConfig;
+
+        private _client?: Client;
 
         constructor(config: NodeProperties) {
             super(RED);
 
             this.createNode(config);
 
-            this.server = RED.nodes.getNode((config as any).server);
+            this.server = RED.nodes.getNode((config as any).server) as any as DolittleRuntimeConfig;
+            if (this.server) {
+                this._client = Client.for(this.server.microservice).build();
+            }
 
             this.on('input', (msg) => {
-                this.send(msg);
+
+                if (this._client) {
+                    if (msg.payload &&
+                        msg.payload.artifact &&
+                        msg.payload.eventSourceId) {
+
+                        this._client.executionContextManager.currentFor(this.server?.tenant || Guid.empty);
+                        if (msg.payload.public) {
+                            this._client.eventStore.commitPublic(msg.payload.content, msg.payload.eventSourceId, msg.payload.artifact);
+                        } else {
+                            this._client.eventStore.commit(msg.content, msg.payload.eventSourceId, msg.payload.artifact);
+                        }
+                    }
+                }
             });
         }
     }

--- a/Source/node-red/nodes/http-auth-config/http-auth-config.html
+++ b/Source/node-red/nodes/http-auth-config/http-auth-config.html
@@ -1,3 +1,5 @@
+<!-- Copyright (c) Dolittle.  All Rights Reserved.  Licensed under the MIT License. See LICENSE file in the project root for full license information. -->
+
 <script type="text/javascript">
     RED.nodes.registerType('http-auth-config', {
         category: 'config',

--- a/Source/node-red/nodes/http-auth-config/http-auth-config.ts
+++ b/Source/node-red/nodes/http-auth-config/http-auth-config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 import { NodeProperties, Red } from 'node-red';
 
 import { Node } from '../../Node';

--- a/Source/node-red/nodes/http-auth-header/http-auth-header.html
+++ b/Source/node-red/nodes/http-auth-header/http-auth-header.html
@@ -1,3 +1,5 @@
+<!-- Copyright (c) Dolittle.  All Rights Reserved.  Licensed under the MIT License. See LICENSE file in the project root for full license information. -->
+
 <script type="text/javascript">
     RED.nodes.registerType('http-auth-header', {
         category: 'function',

--- a/Source/node-red/nodes/http-auth-header/http-auth-header.ts
+++ b/Source/node-red/nodes/http-auth-header/http-auth-header.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 import { NodeProperties, Red } from 'node-red';
 
 import { Node } from '../../Node';

--- a/Source/node-red/package.json
+++ b/Source/node-red/package.json
@@ -53,6 +53,7 @@
     },
     "dependencies": {
         "@dolittle/libertas": "^1.0.0",
+        "@dolittle/sdk": "^1.2.0",
         "@types/mongodb": "^3.5.20",
         "node-red": "^1.0.6"
     }

--- a/Source/node-red/tsconfig.json
+++ b/Source/node-red/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.settings.json",
     "compilerOptions": {
         "rootDir": ".",
-        "baseUrl": "./"
+        "baseUrl": "./",
+        "outDir": "./Distribution"
     }
 }

--- a/Testbench/data/flows.json
+++ b/Testbench/data/flows.json
@@ -28,20 +28,6 @@
         ]
     },
     {
-        "id": "ea70dedd.96ca5",
-        "type": "function",
-        "z": "44b233f4.645aec",
-        "name": "",
-        "func": "\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 170,
-        "y": 620,
-        "wires": [
-            []
-        ]
-    },
-    {
         "id": "302245d3.be6d2a",
         "type": "inject",
         "z": "44b233f4.645aec",
@@ -53,8 +39,8 @@
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 410,
-        "y": 460,
+        "x": 430,
+        "y": 420,
         "wires": [
             [
                 "d17b95d3.d75368"

--- a/Testbench/data/flows.json
+++ b/Testbench/data/flows.json
@@ -1,0 +1,64 @@
+[
+    {
+        "id": "44b233f4.645aec",
+        "type": "tab",
+        "label": "Flow 1",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "da6bfe2a.82fcd",
+        "type": "dolittle-runtime-config",
+        "z": "",
+        "tenant": "c59abefd-f72a-4684-ad7f-dfdd2c466fec",
+        "microservice": "385b8c13-cb2a-409f-87b8-df348cbc4822",
+        "name": "local",
+        "host": "localhost",
+        "port": "50053"
+    },
+    {
+        "id": "d17b95d3.d75368",
+        "type": "event-store",
+        "z": "44b233f4.645aec",
+        "server": "da6bfe2a.82fcd",
+        "x": 690,
+        "y": 420,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "ea70dedd.96ca5",
+        "type": "function",
+        "z": "44b233f4.645aec",
+        "name": "",
+        "func": "\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "x": 170,
+        "y": 620,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "302245d3.be6d2a",
+        "type": "inject",
+        "z": "44b233f4.645aec",
+        "name": "",
+        "topic": "",
+        "payload": "{\"artifact\":\"81274cea-8350-4819-ba71-1369d2ddc1ea\",\"eventSourceId\":\"d87cf960-ff0b-4938-9da6-049ee6aaa438\",\"public\":true,\"content\":{\"hello\":\"world2\"}}",
+        "payloadType": "json",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "x": 410,
+        "y": 460,
+        "wires": [
+            [
+                "d17b95d3.d75368"
+            ]
+        ]
+    }
+]

--- a/Testbench/data/settings.js
+++ b/Testbench/data/settings.js
@@ -79,7 +79,7 @@ module.exports = {
     // Note: once you set this property, do not change it - doing so will prevent
     // node-red from being able to decrypt your existing credentials and they will be
     // lost.
-    //credentialSecret: "a-secret-key",
+    credentialSecret: "0577d43e-b913-4d6f-b364-c4fbabdd5f06",
 
     // By default, all user data is stored in a directory called `.node-red` under
     // the user's home directory. To use a different location, the following

--- a/Testbench/nodemon.json
+++ b/Testbench/nodemon.json
@@ -1,0 +1,9 @@
+{
+    "restartable": "rs",
+    "verbose": false,
+    "watch": [
+        "data",
+        "../Source"
+    ],
+    "ext": "js html css json png"
+}

--- a/Testbench/package.json
+++ b/Testbench/package.json
@@ -5,7 +5,7 @@
     "scripts": {
       "red": "env NODE_TLS_REJECT_UNAUTHORIZED=0 node --inspect=0.0.0.0:9229 node_modules/node-red/red.js --userDir $(pwd)/data",
       "debug_brk": "env NODE_TLS_REJECT_UNAUTHORIZED=0 node --inspect=0.0.0.0:9229 --inspect-brk node_modules/node-red/red.js --userDir $(pwd)/data",
-      "start": "nodemon --watch $(pwd)/data --watch $(pwd)/../Source --watch -e js,html,css,json,png --exec 'yarn red'"
+      "start": "nodemon --exec 'yarn red'"
     },
     "devDependencies": {
       "nodemon": "^2.0.4",


### PR DESCRIPTION
This adds basic support for committing private and public events to the event store. 
It expects a well defined format of : 

```json
{
    "artifact": "<guid>",
    "eventSourceId": "<guid>",
    "public": true || false,
    "content": {
    }
}
```

It leverages the Runtime configuration, which also contains now the configuration of Tenant and Microservice and establishes for each commit the correct execution context for the current async context.